### PR TITLE
Make orthogonalization method chooseable for gmres

### DIFF
--- a/docs/src/linear_systems/gmres.md
+++ b/docs/src/linear_systems/gmres.md
@@ -13,7 +13,7 @@ gmres!
 
 The implementation pre-allocates a matrix $V$ of size `n` by `restart` whose columns form an orthonormal basis for the Krylov subspace. This allows BLAS2 operations when updating the solution vector $x$. The Hessenberg matrix is also pre-allocated.
 
-Modified Gram-Schmidt is used to orthogonalize the columns of $V$ by default, since it is more numerical stable then classical Gram-Schmidt. However will classical Gram-Schmidt (without or with the DGKS correction step) benefit more from multithreading.
+By default, modified Gram-Schmidt is used to orthogonalize the columns of $V$, since it is numerically more stable than classical Gram-Schmidt. Modified Gram-Schmidt is however inherently sequential, and if stability is not a concern, classical Gram-Schmidt can be used, which is implemented using BLAS2 operations. As a compromise the "DGKS criterion" can be used, which conditionally applies classical Gram-Schmidt repeatedly to stabilize it, and is typically one to two times slower than classical Gram-Schmidt. 
 
 The computation of the residual norm is implemented in a non-standard way, namely keeping track of a vector $\gamma$ in the null-space of $H_k^*$, which is the adjoint of the $(k + 1) \times k$ Hessenberg matrix $H_k$ at the $k$th iteration. Only when $x$ needs to be updated is the Hessenberg matrix mutated with Givens rotations.
 

--- a/docs/src/linear_systems/gmres.md
+++ b/docs/src/linear_systems/gmres.md
@@ -13,7 +13,7 @@ gmres!
 
 The implementation pre-allocates a matrix $V$ of size `n` by `restart` whose columns form an orthonormal basis for the Krylov subspace. This allows BLAS2 operations when updating the solution vector $x$. The Hessenberg matrix is also pre-allocated.
 
-Modified Gram-Schmidt is used to orthogonalize the columns of $V$.
+Modified Gram-Schmidt is used to orthogonalize the columns of $V$ by default, since it is more numerical stable then classical Gram-Schmidt. However will classical Gram-Schmidt (without or with the DGKS correction step) benefit more from multithreading.
 
 The computation of the residual norm is implemented in a non-standard way, namely keeping track of a vector $\gamma$ in the null-space of $H_k^*$, which is the adjoint of the $(k + 1) \times k$ Hessenberg matrix $H_k$ at the $k$th iteration. Only when $x$ needs to be updated is the Hessenberg matrix mutated with Givens rotations.
 

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -113,7 +113,7 @@ function gmres_iterable!(x, A, b;
                          restart::Int = min(20, size(A, 2)),
                          maxiter::Int = size(A, 2),
                          initially_zero::Bool = false,
-                         orth_meth = ModifiedGramSchmidt)
+                         orth_meth::OrthogonalizationMethod = ModifiedGramSchmidt())
     T = eltype(x)
 
     # Approximate solution
@@ -168,7 +168,7 @@ Solves the problem ``Ax = b`` with restarted GMRES.
 - `Pr`: right preconditioner;
 - `log::Bool`: keep track of the residual norm in each iteration;
 - `verbose::Bool`: print convergence information during the iterations.
-- `orth_meth = ModifiedGramSchmidt`: orthogonalization method (ModifiedGramSchmidt, ClassicalGramSchmidt, DGKS)
+- `orth_meth::OrthogonalizationMethod = ModifiedGramSchmidt()`: orthogonalization method (ModifiedGramSchmidt(), ClassicalGramSchmidt(), DGKS())
 
 # Return values
 
@@ -191,7 +191,7 @@ function gmres!(x, A, b;
                 log::Bool = false,
                 initially_zero::Bool = false,
                 verbose::Bool = false,
-                orth_meth = ModifiedGramSchmidt)
+                orth_meth::OrthogonalizationMethod = ModifiedGramSchmidt())
     history = ConvergenceHistory(partial = !log, restart = restart)
     history[:abstol] = abstol
     history[:reltol] = reltol

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -190,7 +190,7 @@ function gmres!(x, A, b;
                 log::Bool = false,
                 initially_zero::Bool = false,
                 verbose::Bool = false,
-                orth_meth = ModifiedGramSchmidt)
+                orth_meth::OrthogonalizationMethod = ModifiedGramSchmidt)
     history = ConvergenceHistory(partial = !log, restart = restart)
     history[:abstol] = abstol
     history[:reltol] = reltol

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -168,6 +168,7 @@ Solves the problem ``Ax = b`` with restarted GMRES.
 - `Pr`: right preconditioner;
 - `log::Bool`: keep track of the residual norm in each iteration;
 - `verbose::Bool`: print convergence information during the iterations.
+- `orth_meth = ModifiedGramSchmidt`: orthogonalization method (ModifiedGramSchmidt, ClassicalGramSchmidt, DGKS)
 
 # Return values
 
@@ -190,7 +191,7 @@ function gmres!(x, A, b;
                 log::Bool = false,
                 initially_zero::Bool = false,
                 verbose::Bool = false,
-                orth_meth::OrthogonalizationMethod = ModifiedGramSchmidt)
+                orth_meth = ModifiedGramSchmidt)
     history = ConvergenceHistory(partial = !log, restart = restart)
     history[:abstol] = abstol
     history[:reltol] = reltol

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -7,9 +7,10 @@ struct ClassicalGramSchmidt <: OrthogonalizationMethod end
 struct ModifiedGramSchmidt <: OrthogonalizationMethod end
 
 # Default to MGS, good enough for solving linear systems.
-@inline orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}) where {T} = orthogonalize_and_normalize!(V, w, h, ModifiedGramSchmidt)
+@inline orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}) where {T} = 
+	orthogonalize_and_normalize!(V, w, h, ModifiedGramSchmidt())
 
-function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{DGKS}) where {T}
+function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::DGKS) where {T}
     # Orthogonalize using BLAS-2 ops
     mul!(h, adjoint(V), w)
     mul!(w, V, h, -one(T), one(T))
@@ -37,7 +38,7 @@ function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, 
     nrm
 end
 
-function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ClassicalGramSchmidt}) where {T}
+function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::ClassicalGramSchmidt) where {T}
     # Orthogonalize using BLAS-2 ops
     mul!(h, adjoint(V), w)
     mul!(w, V, h, -one(T), one(T))
@@ -49,7 +50,7 @@ function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, 
     nrm
 end
 
-function orthogonalize_and_normalize!(V::StridedVector{Vector{T}}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ModifiedGramSchmidt}) where {T}
+function orthogonalize_and_normalize!(V::StridedVector{Vector{T}}, w::StridedVector{T}, h::StridedVector{T}, ::ModifiedGramSchmidt) where {T}
     # Orthogonalize using BLAS-1 ops
     for i = 1 : length(V)
         h[i] = dot(V[i], w)
@@ -63,7 +64,7 @@ function orthogonalize_and_normalize!(V::StridedVector{Vector{T}}, w::StridedVec
     nrm
 end
 
-function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ModifiedGramSchmidt}) where {T}
+function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::ModifiedGramSchmidt) where {T}
     # Orthogonalize using BLAS-1 ops and column views.
     for i = 1 : size(V, 2)
         column = view(V, :, i)

--- a/test/orthogonalize.jl
+++ b/test/orthogonalize.jl
@@ -34,7 +34,7 @@ m = 3
     end
 
     # Assuming V is a matrix
-    @testset "Using $method" for method = (DGKS, ClassicalGramSchmidt, ModifiedGramSchmidt)
+    @testset "Using $method" for method = (DGKS(), ClassicalGramSchmidt(), ModifiedGramSchmidt())
 
         # Projection size
         h = zeros(T, m)
@@ -55,7 +55,7 @@ m = 3
 
         # Orthogonalize w in-place
         w = copy(w_original)
-        nrm = orthogonalize_and_normalize!(V_vec, w, h, ModifiedGramSchmidt)
+        nrm = orthogonalize_and_normalize!(V_vec, w, h, ModifiedGramSchmidt())
 
         is_orthonormalized(w, h, nrm)
     end


### PR DESCRIPTION
When using multithreading, Classical Gram-Schmidt with and without the DGKS correction step provides better runtimes then Modified Gram-Schmidt (since they use BLAS level 2 instead of level 1). 
The following shows GMRES solving the Bourchtein/atmosmodd linear system from SuiteSparse using the first from the two RHS which come with the matrix. All three runs converged after 1497 iterations (so at least for this linear system round off errors doesn't seem to be a problem).
![orth_meth](https://user-images.githubusercontent.com/63021020/111802093-e8c79800-88cd-11eb-8bfc-4cdc9c2f3e86.png)

Since CGS and DGKS are already implemented, I just made them choosable when calling gmres. Set MGS the default, since it might be the best without multithreading.