### PR TITLE
remove type conversion for tmpm tmpn in LSQR

### DIFF
--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -110,8 +110,8 @@ function lsqr_method!(log::ConvergenceHistory, x, A, b;
     Anorm = Acond = ddnorm = res2 = xnorm = xxnorm = z = sn2 = zero(Tr)
     cs2 = -one(Tr)
     dampsq = abs2(damp)
-    tmpm = similar(b, T, m)
-    tmpn = similar(x, T, n)
+    tmpm = similar(b)
+    tmpn = similar(x)
 
     log[:atol] = atol
     log[:btol] = btol


### PR DESCRIPTION
The type conversion `T` seems unnecessary and will throw error especially when strict input/output types are specified for the linear operator `A`. For example, when `A` takes complex input and produces real output, `x` is complex, `b` is real, this `similar(b, T, m)` will make `tmpm` complex, which is not necessary since `b` is always real. Any thought? Thanks