### PR TITLE
fix typos

### DIFF
--- a/docs/src/eigenproblems/power_method.md
+++ b/docs/src/eigenproblems/power_method.md
@@ -12,4 +12,4 @@ invpowm!
 ```
 
 ## Implementation details
-Storage requirements are 3 vectors: the approximate eigenvector `x`, the residual vector `r` and a temporary. The residual norm lags behind one iteration, as it is computed when $Ax$ is performed. Therefore the final resdiual norm is even smaller.
+Storage requirements are 3 vectors: the approximate eigenvector `x`, the residual vector `r` and a temporary. The residual norm lags behind one iteration, as it is computed when $Ax$ is performed. Therefore the final residual norm is even smaller.

--- a/docs/src/linear_systems/bicgstabl.md
+++ b/docs/src/linear_systems/bicgstabl.md
@@ -1,6 +1,6 @@
 # [BiCGStab(l)](@id BiCGStabl)
 
-BiCGStab(l) solves the problem $Ax = b$ approximately for $x$ where $A$ is a general, linear operator and $b$ the right-hand side vector. The methods combines BiCG with $l$ GMRES iterations, resulting in a short-reccurence iteration. As a result the memory is fixed as well as the computational costs per iteration.
+BiCGStab(l) solves the problem $Ax = b$ approximately for $x$ where $A$ is a general, linear operator and $b$ the right-hand side vector. The methods combines BiCG with $l$ GMRES iterations, resulting in a short-recurrence iteration. As a result the memory is fixed as well as the computational costs per iteration.
 
 ## Usage
 

--- a/src/history.jl
+++ b/src/history.jl
@@ -172,8 +172,8 @@ function reserve!(typ::Type, ch::ConvergenceHistory, key::Symbol, kwargs...)
     _reserve!(typ, ch, key, kwargs...)
 end
 
-#If partialhistory, theres no need to store a vector or matrix, instead
-#store nothing or store a vector respectively.
+# If PartialHistory, there's no need to store a vector or matrix, instead
+# store nothing or store a vector respectively.
 _reserve!(typ::Type, ch::PartialHistory, key::Symbol, ::Int) = nothing
 function _reserve!(typ::Type, ch::PartialHistory, key::Symbol, ::Int, size::Int)
     ch.data[key] = Vector{typ}(undef, size)


### PR DESCRIPTION
docs/src/eigenproblems/power_method.md
docs/src/linear_systems/bicgstabl.md
src/history.jl

I used CamelCase in the following comment.

```
$ ed -s IterativeSolvers.jl/src/history.jl <<<'175,176p'
# If PartialHistory, there's no need to store a vector or matrix, instead
# store nothing or store a vector respectively.
$ 
```