### PR TITLE
Modification to prevent scalar indexing on CUDA devices

### DIFF
--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -98,9 +98,11 @@ function lsqr_method!(log::ConvergenceHistory, x, A, b;
     n = size(A,2)
     length(x) == n || error("x should be of length ", n)
     length(b) == m || error("b should be of length ", m)
-    for i = 1:n
-        isfinite(x[i]) || error("Initial guess for x must be finite")
+    
+    if !(all(isfinite.(x)))
+      error("Initial guess for x must be finite")
     end
+
 
     # Initialize
     T = Adivtype(A, b)


### PR DESCRIPTION
Scalar indexing on CUDA devices results in poor performance. This modification uses dot syntax to prevent scalar indexing.