### PR TITLE
Docs: fix build, highlight non-square options

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 
 [compat]
-Documenter = "~0.26, 0.27, 1.0, 1.1"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
   ),
 	doctest = false,
 	clean = true,
+	checkdocs = :none,   # consider changing to :exports, but, e.g., `?IterativeSolvers` itself seems silly to include in the docs
 	sitename = "IterativeSolvers.jl",
 	pages = [
 		"Home" => "index.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,6 +8,8 @@ For more information on future methods have a look at the package [roadmap](http
 
 ## What method should I use for linear systems?
 
+### Square linear systems
+
 When solving linear systems $Ax = b$ for a square matrix $A$ there are quite some options. The typical choices are listed below:
 
 | Method              | When to use it                                                           |
@@ -22,7 +24,10 @@ We also offer [Chebyshev iteration](@ref Chebyshev) as an alternative to Conjuga
 
 Stationary methods like [Jacobi](@ref), [Gauss-Seidel](@ref), [SOR](@ref) and [SSOR](@ref) can be used as smoothers to reduce high-frequency components in the error in just a few iterations.
 
-When solving **least-squares** problems we currently offer just [LSMR](@ref LSMR) and [LSQR](@ref LSQR).
+### Non-square systems: least squares
+
+When solving **least-squares** problems we currently offer [LSMR](@ref LSMR) and [LSQR](@ref LSQR).
+LSMR generally converges more quickly than LSQR.
 
 ## Eigenproblems and SVD
 


### PR DESCRIPTION
This increases the visibility of the least-squares solvers and clarifies that all algorithms in "What method should I use for linear systems?" refer only to square linear systems.

Closes #353