### PR TITLE
Fix Chebyshev iteration recurrence to use previous direction vector

### DIFF
--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -42,7 +42,7 @@ function iterate(cheb::ChebyshevIterable, iteration::Int=start(cheb))
     else
         β = (cheb.λ_diff * cheb.α / 2) ^ 2
         cheb.α = inv(cheb.λ_avg - β)
-        cheb.u .= cheb.c .+ β .* cheb.c
+        cheb.u .= cheb.c .+ β .* cheb.u
     end
 
     mul!(cheb.c, cheb.A, cheb.u)


### PR DESCRIPTION
Hi, thank you for this great package.
I noticed that the current Chebyshev iteration may use an incorrect update for the direction vector. This PR fixes it by using the previous direction vector in the recurrence relation.